### PR TITLE
Added https:// to set set 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ still in progress
 
 # setup
 
-0. `git clone github.com/mhfowler/slacktoarena ~/slacktoarena`
+0. `git clone https://github.com/mhfowler/slack-to-arena.git`
 
 1. `cd ~/slacktoarena` 
 


### PR DESCRIPTION
If you copy `git clone github.com/mhfowler/slack-to-arena.git` it will not run with out http:// before the url